### PR TITLE
chore: initialize PNPM with workspaces for ./packages/* and ./sites/*

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+link-workspace-packages = true

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "stage-monorepo",
+  "version": "0.0.1",
+  "description": "mono repo for STAGE and friends",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "packageManager": "pnpm@8.10.2",
+	"engines": {
+		"pnpm": "^8.0.0"
+	}
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - 'packages/*'
+  - 'sites/*'
+  - '!.test-tmp/**'
+  - 'playgrounds/*'


### PR DESCRIPTION
**Summary:**
Initialize PNPM with workspaces for better dependency management.

**Changes:**
- Added PNPM as the package manager.
- Enabled workspaces for './packages/*' and './sites/*' directories.

**Related Issues:**
Closes #3 

**Additional Information:**
- Ensure that PNPM is installed globally before using the project.
- Verify that workspaces are functioning as expected.